### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ APToast can display one or more toast notifications queued one by one. Toasts ca
 pod 'APToast'
 ```
  - **Manual:**
-Copy `APToast/APToast` folder anywhere to your project and add it to XCode.
+Copy `APToast/APToast` folder anywhere to your project and add it to Xcode.
 
 ##Sample
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
