### PR TITLE
Fix Xcode9 warnings

### DIFF
--- a/APToast.podspec
+++ b/APToast.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "APToast"
-  s.version      = "1.1"
+  s.version      = "1.2"
   s.summary      = "A UIView category to provide rich toast notifications."
   s.description  = 'APToast can display one or more toast notifications queued one by one. '\
                    'Toasts can be NSString objects or custom UIView class. '\
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/podkovyrin/APToast"
   s.license      = 'MIT'
   s.author       = { "Andrew Podkovyrin" => "podkovyin@gmail.com" }
-  s.source       = { :git => "https://github.com/podkovyrin/APToast.git", :tag => "1.1" }
+  s.source       = { :git => "https://github.com/podkovyrin/APToast.git", :tag => "1.2" }
   s.platform     = :ios, '6.0'
   s.source_files = 'APToast/APToast/*.{h,m}'
   s.requires_arc = true

--- a/APToast/APToast/APToast.h
+++ b/APToast/APToast/APToast.h
@@ -41,7 +41,7 @@
 /**
  *  The block to execute when toasting completes
  */
-@property (copy, readwrite, nonatomic) void (^completionBlock)();
+@property (copy, readwrite, nonatomic) void (^completionBlock)(void);
 
 /**
  *  Starts toasting timer

--- a/APToast/APToast/APToaster.h
+++ b/APToast/APToast/APToaster.h
@@ -32,7 +32,7 @@
             parentView:(UIView *)parentView
               duration:(NSTimeInterval)duration
          tapToComplete:(BOOL)tapToComplete
-            completion:(void (^)())completion;
+            completion:(void (^)(void))completion;
 
 /**
  *  Ejects `toastView` from toasting queue with the given `toastID`

--- a/APToast/APToast/UIView+APToast.h
+++ b/APToast/APToast/UIView+APToast.h
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSInteger, APToastPosition) {
  *
  *  @return Unique auto-generated `toastID`, which can be used to force early completion toasting or `NSNotFound` (if toast not queued due to incorrect parameters)
  */
-- (NSInteger)ap_makeToast:(NSString *)toastText duration:(NSTimeInterval)duration position:(APToastPosition)position completion:(void (^)())completion;
+- (NSInteger)ap_makeToast:(NSString *)toastText duration:(NSTimeInterval)duration position:(APToastPosition)position completion:(void (^)(void))completion;
 
 /**
  *  Make simple toast with `toastText`.
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSInteger, APToastPosition) {
                  duration:(NSTimeInterval)duration
                    center:(CGPoint)center
             tapToComplete:(BOOL)tapToComplete
-               completion:(void (^)())completion;
+               completion:(void (^)(void))completion;
 
 ///------------------------------------------------
 /// @name Make custom view toast
@@ -136,7 +136,7 @@ typedef NS_ENUM(NSInteger, APToastPosition) {
                      duration:(NSTimeInterval)duration
                        center:(CGPoint)center
                 tapToComplete:(BOOL)tapToComplete
-                   completion:(void (^)())completion;
+                   completion:(void (^)(void))completion;
 
 ///------------------------------------------------
 /// @name Eject toast


### PR DESCRIPTION
Since Xcode9, where CLANG_WARN_STRICT_PROTOTYPES is recommended, some of declarations aren't prototypes - 5 warnings were produced.